### PR TITLE
renovate: add missing regex groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
         "^Dockerfile$"
       ],
       "matchStrings": [
-        "ARG [^\\s]+=\"([^\\s]+)\" # renovate: image=([^\\s]+)\\n"
+        "ARG [^\\s]+=\"(?<currentValue>[^\\s]+)\" # renovate: image=(?<depName>[^\\s]+)\\n"
       ]
     }
   ]


### PR DESCRIPTION
```
Reason: The renovate configuration file contains some invalid settings

Message: Regex Managers must contain currentValueTemplate configuration or regex group named currentValue, Regex Managers must contain depName or packageName regex groups or templates
```